### PR TITLE
Fix typo in link format in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This will add `/graphql` and `/graphiql` endpoints to your app.
  * `root_value`: The `root_value` you want to provide to `executor.execute`.
  * `pretty`: Whether or not you want the response to be pretty printed JSON.
  * `executor`: The `Executor` that you want to use to execute queries.
- * `graphiql`: If `True`, may present [GraphiQL][https://github.com/graphql/graphiql] when loaded directly
+ * `graphiql`: If `True`, may present [GraphiQL](https://github.com/graphql/graphiql) when loaded directly
     from a browser (a useful tool for debugging and exploration).
 
 You can also subclass `GraphQLView` and overwrite `get_root_value(self, request)` to have a dynamic root value


### PR DESCRIPTION
I do not really know why there are 2 READMEs in this project. :confused: But the *.md, rendered by Github, have a typo that breaks the formatting. :v: