### PR TITLE
Use context option (if provided)

### DIFF
--- a/flask_graphql/graphqlview.py
+++ b/flask_graphql/graphqlview.py
@@ -47,7 +47,7 @@ class GraphQLView(View):
         return self.root_value
 
     def get_context(self, request):
-        return request
+        return self.context or request
 
     def get_middleware(self, request):
         return self.middleware


### PR DESCRIPTION
Related to https://github.com/graphql-python/flask-graphql/issues/18

Currently, the `GraphQLView` class accepts the `context` keyword argument when initializing, but it's not using it to set the `context_value` when executing the query.

This PR modifies the `get_context` instance method inside `GraphQLView` so that the `context` option is used when it is provided, defaulting to `request` otherwise.