### PR TITLE
Added batch support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ from flask_graphql import GraphQLView
 
 app.add_url_rule('/graphql', view_func=GraphQLView.as_view('graphql', schema=schema, graphiql=True))
 
+# Optional, for adding batch query support (used in Apollo-Client)
+app.add_url_rule('/graphql/batch', view_func=GraphQLView.as_view('graphql', schema=schema, batch=True))
 ```
 
 This will add `/graphql` and `/graphiql` endpoints to your app.

--- a/tests/app.py
+++ b/tests/app.py
@@ -3,10 +3,10 @@ from flask_graphql import GraphQLView
 from .schema import Schema
 
 
-def create_app(**kwargs):
+def create_app(path='/graphql', **kwargs):
     app = Flask(__name__)
     app.debug = True
-    app.add_url_rule('/graphql', view_func=GraphQLView.as_view('graphql', schema=Schema, **kwargs))
+    app.add_url_rule(path, view_func=GraphQLView.as_view('graphql', schema=Schema, **kwargs))
     return app
 
 


### PR DESCRIPTION
This PR adds batch support to `Flask-GraphQL`.

It can be used like:

```python
app.add_url_rule('/graphql/batch', view_func=GraphQLView.as_view('graphql', schema=schema, batch=True))
```