### PR TITLE
Added the ability to specify the JSON encoder

### DIFF
--- a/flask_graphql/graphqlview.py
+++ b/flask_graphql/graphqlview.py
@@ -33,6 +33,7 @@ class GraphQLView(View):
     graphiql_template = None
     middleware = None
     batch = False
+    json_encoder = None
 
     methods = ['GET', 'POST', 'PUT', 'DELETE']
 
@@ -142,10 +143,10 @@ class GraphQLView(View):
     def json_encode(self, request, d, show_graphiql=False):
         pretty = self.pretty or show_graphiql or request.args.get('pretty')
         if not pretty:
-            return json.dumps(d, separators=(',', ':'))
+            return json.dumps(d, separators=(',', ':'), cls=self.json_encoder)
 
-        return json.dumps(d, sort_keys=True,
-                          indent=2, separators=(',', ': '))
+        return json.dumps(d, sort_keys=True, indent=2,
+                          separators=(',', ': '), cls=self.json_encoder)
 
     # noinspection PyBroadException
     def parse_body(self, request):

--- a/tests/encoder.py
+++ b/tests/encoder.py
@@ -1,0 +1,6 @@
+from json import JSONEncoder
+
+
+class TestJSONEncoder(JSONEncoder):
+    def encode(self, o):
+        return 'TESTSTRING'

--- a/tests/test_graphqlview.py
+++ b/tests/test_graphqlview.py
@@ -12,6 +12,7 @@ except ImportError:
     from urllib.parse import urlencode
 
 from .app import create_app
+from .encoder import TestJSONEncoder
 from flask import url_for
 
 
@@ -500,8 +501,8 @@ def test_batch_supports_post_json_query_with_json_variables(client):
         'payload': { 'data': {'test': "Hello Dolly"} },
         'status': 200,
     }]
- 
-          
+
+
 @pytest.mark.parametrize('app', [create_app(batch=True)])
 def test_batch_allows_post_with_operation_name(client):
     response = client.post(
@@ -532,3 +533,11 @@ def test_batch_allows_post_with_operation_name(client):
         },
         'status': 200,
     }]
+
+
+@pytest.mark.parametrize('app', [create_app(json_encoder=TestJSONEncoder)])
+def test_custom_encoder(client):
+    response = client.get(url_string(query='{test}'))
+
+    # TestJSONEncoder just encodes everything to 'TESTSTRING'
+    assert response.data.decode() == 'TESTSTRING'


### PR DESCRIPTION
`json.dumps()` allows for a JSON encoder to be specified by the `cls` argument. This PR allows for a JSONEncoder to be passed through when constructing the GraphQLView object.

Supporting this PR allows for serialization of custom types which can be particular useful when defining custom graphene scalar types.