### PR TITLE
Throw more sensible error in empty batch query

### DIFF
--- a/flask_graphql/graphqlview.py
+++ b/flask_graphql/graphqlview.py
@@ -76,6 +76,8 @@ class GraphQLView(View):
             show_graphiql = self.graphiql and self.can_display_graphiql(data)
 
             if self.batch:
+                if not data:
+                    raise HttpError(BadRequest('Must have at least one query in batch'))
                 responses = [self.get_response(request, entry) for entry in data]
                 result = '[{}]'.format(','.join([response[0] for response in responses]))
                 status_code = max(responses, key=lambda response: response[1])[1]


### PR DESCRIPTION
With a view constructed as:

```python
view = GraphQLView.as_view('graphql_batch', schema=schema, batch=True)
app.add_url_rule('/graphql/batch`, view_func=view)
```

Simply navigating to the URI in a browser (and thus submitting no queries) results in an empty list of responses [here](https://github.com/graphql-python/flask-graphql/blob/v1.4.1/flask_graphql/graphqlview.py#L81), which causes `ValueError: max() arg is an empty sequence`

---

This PR raises a BadRequest error if there are no queries in a batch, which produces a more sensible error message than what currently happens.  

Having not looked at the GraphQL specs in-depth, it's debatable as to whether this behavior or returning an empty list of results with status=200 is the more desirable option.  However, an empty list of queries is almost certainly an error on the client side and raising error in that event makes that situation easier to troubleshoot.  Either outcome is better than the current situation, however.