### PR TITLE
Customizable HTML title in GraphiQL

### DIFF
--- a/flask_graphql/graphqlview.py
+++ b/flask_graphql/graphqlview.py
@@ -19,6 +19,7 @@ class GraphQLView(View):
     graphiql = False
     graphiql_version = None
     graphiql_template = None
+    graphiql_html_title = None
     middleware = None
     batch = False
 
@@ -51,6 +52,7 @@ class GraphQLView(View):
             result=result,
             graphiql_version=self.graphiql_version,
             graphiql_template=self.graphiql_template,
+            graphiql_html_title=self.graphiql_html_title,
         )
 
     format_error = staticmethod(default_format_error)

--- a/flask_graphql/render_graphiql.py
+++ b/flask_graphql/render_graphiql.py
@@ -12,6 +12,7 @@ add "&raw" to the end of the URL within a browser.
 <!DOCTYPE html>
 <html>
 <head>
+  <title>{{graphiql_html_title|default("GraphiQL", true)}}</title>
   <style>
     html, body {
       height: 100%;
@@ -123,13 +124,15 @@ add "&raw" to the end of the URL within a browser.
 </html>'''
 
 
-def render_graphiql(params, result, graphiql_version=None, graphiql_template=None):
+def render_graphiql(params, result, graphiql_version=None,
+                    graphiql_template=None, graphiql_html_title=None):
     graphiql_version = graphiql_version or GRAPHIQL_VERSION
     template = graphiql_template or TEMPLATE
 
     return render_template_string(
         template,
         graphiql_version=graphiql_version,
+        graphiql_html_title=graphiql_html_title,
         result=result,
         params=params
     )

--- a/tests/test_graphiqlview.py
+++ b/tests/test_graphiqlview.py
@@ -26,3 +26,14 @@ def test_graphiql_renders_pretty(client):
     ).replace("\"","\\\"").replace("\n","\\n")
 
     assert pretty_response in response.data.decode('utf-8')
+
+
+def test_graphiql_default_title(client):
+    response = client.get(url_for('graphql'), headers={'Accept': 'text/html'})
+    assert '<title>GraphiQL</title>' in response.data.decode('utf-8')
+
+
+@pytest.mark.parametrize('app', [create_app(graphiql=True, graphiql_html_title="Awesome")])
+def test_graphiql_custom_title(client):
+    response = client.get(url_for('graphql'), headers={'Accept': 'text/html'})
+    assert '<title>Awesome</title>' in response.data.decode('utf-8')


### PR DESCRIPTION
It's nice to have an HTML `<title>` element on the page, so that it's easier for the developer to identify which browser tab is which. This pull request adds a customizable `<title>` element, so that you can make the title refer to your project if you want.