### PR TITLE
Add documenation that flask-graphql supports middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ This will add `/graphql` and `/graphiql` endpoints to your app.
  * `graphiql`: If `True`, may present [GraphiQL](https://github.com/graphql/graphiql) when loaded directly from a browser (a useful tool for debugging and exploration).
  * `graphiql_template`: Inject a Jinja template string to customize GraphiQL.
  * `batch`: Set the GraphQL view as batch (for using in [Apollo-Client](http://dev.apollodata.com/core/network.html#query-batching) or [ReactRelayNetworkLayer](https://github.com/nodkz/react-relay-network-layer))
+ * `middleware`: A list of graphql [middlewares](http://docs.graphene-python.org/en/latest/execution/middleware/).
 
 You can also subclass `GraphQLView` and overwrite `get_root_value(self, request)` to have a dynamic root value
 per request.


### PR DESCRIPTION
The included docs link is to the Graphene docs. GraphQL middleware in Python isn't specific to Graphene, but I couldn't find any vanilla Python graphql-core docs anywhere.