### PR TITLE
Multipart Request Spec

### DIFF
--- a/flask_graphql/graphqlview.py
+++ b/flask_graphql/graphqlview.py
@@ -136,7 +136,7 @@ class GraphQLView(View):
         elif content_type == 'application/json':
             return load_json_body(request.data.decode('utf8'))
 
-        elif content_type in 'application/x-www-form-urlencoded':
+        elif content_type == 'application/x-www-form-urlencoded':
             return request.form
 
         elif content_type == 'multipart/form-data':

--- a/flask_graphql/graphqlview.py
+++ b/flask_graphql/graphqlview.py
@@ -2,6 +2,7 @@ from functools import partial
 
 from flask import Response, request
 from flask.views import View
+
 from graphql.type.schema import GraphQLSchema
 from graphql_server import (HttpQueryError, default_format_error,
                             encode_execution_results, json_encode,

--- a/flask_graphql/graphqlview.py
+++ b/flask_graphql/graphqlview.py
@@ -142,12 +142,11 @@ class GraphQLView(View):
         elif content_type == 'multipart/form-data':
             operations = load_json_body(request.form['operations'])
             files_map = load_json_body(request.form['map'])
-            new_ops = place_files_in_operations(
+            return place_files_in_operations(
                 operations,
                 files_map,
                 request.files
             )
-            return new_ops
         return {}
 
     def should_display_graphiql(self):

--- a/flask_graphql/utils.py
+++ b/flask_graphql/utils.py
@@ -1,13 +1,10 @@
-from copy import copy
-
-
 def place_files_in_operations(operations, files_map, files):
     paths_to_key = (
         (value.split('.'), key)
         for key, values in files_map.items()
         for value in values
     )
-    output = {}
+    output = new_merged_dict(operations)
     output.update(operations)
     for path, key in paths_to_key:
         file_obj = files[key]
@@ -21,22 +18,24 @@ def add_file_to_operations(operations, file_obj, path):
     if isinstance(operations, dict):
         key = path[0]
         sub_dict = add_file_to_operations(operations[key], file_obj, path[1:])
-        return merge_dicts(
-            operations,
-            {key: sub_dict},
-        )
+        return new_merged_dict(operations, {key: sub_dict})
     if isinstance(operations, list):
         index = int(path[0])
         sub_item = add_file_to_operations(operations[index], file_obj, path[1:])
-        return operations[:index] + [sub_item] + operations[index+1:]
+        return new_list_with_replaced_item(operations, index, sub_item)
     return TypeError('Operations must be a JSON data structure')
 
 
-def merge_dicts(*dicts):
+def new_merged_dict(*dicts):
     # Necessary for python2 support
-    if not dicts:
-        return {}
-    output = copy(dicts[0])
-    for d in dicts[1:]:
+    output = {}
+    for d in dicts:
         output.update(d)
+    return output
+
+
+def new_list_with_replaced_item(input_list, index, new_value):
+    # Necessary for python2 support
+    output = [i for i in input_list]
+    output[index] = new_value
     return output

--- a/flask_graphql/utils.py
+++ b/flask_graphql/utils.py
@@ -1,0 +1,42 @@
+from copy import copy
+
+
+def place_files_in_operations(operations, files_map, files):
+    paths_to_key = (
+        (value.split('.'), key)
+        for key, values in files_map.items()
+        for value in values
+    )
+    output = {}
+    output.update(operations)
+    for path, key in paths_to_key:
+        file_obj = files[key]
+        output = add_file_to_operations(output, file_obj, path)
+    return output
+
+
+def add_file_to_operations(operations, file_obj, path):
+    if not path:
+        return file_obj
+    if isinstance(operations, dict):
+        key = path[0]
+        sub_dict = add_file_to_operations(operations[key], file_obj, path[1:])
+        return merge_dicts(
+            operations,
+            {key: sub_dict},
+        )
+    if isinstance(operations, list):
+        index = int(path[0])
+        sub_item = add_file_to_operations(operations[index], file_obj, path[1:])
+        return operations[:index] + [sub_item] + operations[index+1:]
+    return TypeError('Operations must be a JSON data structure')
+
+
+def merge_dicts(*dicts):
+    # Necessary for python2 support
+    if not dicts:
+        return {}
+    output = copy(dicts[0])
+    for d in dicts[1:]:
+        output.update(d)
+    return output

--- a/flask_graphql/utils.py
+++ b/flask_graphql/utils.py
@@ -1,12 +1,13 @@
 def place_files_in_operations(operations, files_map, files):
-    paths_to_key = (
+    path_to_key_iter = (
         (value.split('.'), key)
         for key, values in files_map.items()
         for value in values
     )
-    output = new_merged_dict(operations)
-    output.update(operations)
-    for path, key in paths_to_key:
+    # Since add_files_to_operations returns a new dict/list, first define
+    # output to be operations itself
+    output = operations
+    for path, key in path_to_key_iter:
         file_obj = files[key]
         output = add_file_to_operations(output, file_obj, path)
     return output

--- a/tests/schema.py
+++ b/tests/schema.py
@@ -1,10 +1,19 @@
-from graphql.type.definition import GraphQLArgument, GraphQLField, GraphQLNonNull, GraphQLObjectType
+from graphql.type.definition import GraphQLArgument, GraphQLField, GraphQLNonNull, GraphQLObjectType, GraphQLList
 from graphql.type.scalars import GraphQLString, GraphQLScalarType
 from graphql.type.schema import GraphQLSchema
 
 
 def resolve_test_file(obj, info, what):
-    return what.readline().decode('utf-8')
+    output = what.readline().decode('utf-8')
+    what.seek(0)
+    return output
+
+
+def resolve_test_files(obj, info, whats):
+    output = ''.join(what.readline().decode('utf-8') for what in whats)
+    for what in whats:
+        what.seek(0)
+    return output
 
 
 def resolve_raises(*_):
@@ -42,6 +51,13 @@ QueryRootType = GraphQLObjectType(
             },
             resolver=resolve_test_file,
         ),
+        'testMultiFile': GraphQLField(
+            type=GraphQLString,
+            args={
+                'whats': GraphQLArgument(GraphQLNonNull(GraphQLList(GraphQLUpload))),
+            },
+            resolver=resolve_test_files,
+        )
     }
 )
 

--- a/tests/schema.py
+++ b/tests/schema.py
@@ -1,11 +1,24 @@
 from graphql.type.definition import GraphQLArgument, GraphQLField, GraphQLNonNull, GraphQLObjectType
-from graphql.type.scalars import GraphQLString
+from graphql.type.scalars import GraphQLString, GraphQLScalarType
 from graphql.type.schema import GraphQLSchema
+
+
+def resolve_test_file(obj, info, what):
+    return what.readline().decode('utf-8')
 
 
 def resolve_raises(*_):
     raise Exception("Throws!")
 
+
+# This scalar should be added to graphql-core at some point
+GraphQLUpload = GraphQLScalarType(
+    name="Upload",
+    description="The `Upload` scalar type represents an uploaded file",
+    serialize=lambda x: None,
+    parse_value=lambda x: x,
+    parse_literal=lambda x: x,
+)
 
 QueryRootType = GraphQLObjectType(
     name='QueryRoot',
@@ -21,7 +34,14 @@ QueryRootType = GraphQLObjectType(
                 'who': GraphQLArgument(GraphQLString)
             },
             resolver=lambda obj, info, who='World': 'Hello %s' % who
-        )
+        ),
+        'testFile': GraphQLField(
+            type=GraphQLString,
+            args={
+                'what': GraphQLArgument(GraphQLNonNull(GraphQLUpload)),
+            },
+            resolver=resolve_test_file,
+        ),
     }
 )
 

--- a/tests/test_graphqlview.py
+++ b/tests/test_graphqlview.py
@@ -524,6 +524,7 @@ def test_post_multipart_data_multi(client):
             }},
         ]
 
+
 @pytest.mark.parametrize('app', [create_app(batch=True)])
 def test_batch_allows_post_with_json_encoding(client):
     response = client.post(


### PR DESCRIPTION
As mentioned in #33, it would be nice to support file uploads. This PR implements the [multipart request spec](https://github.com/jaydenseric/graphql-multipart-request-spec) for graphql-flask. 

If it's preferable to move the logic somewhere else (either a more general library or a plugin), please let me know.