### PR TITLE
Add package name for easy copy-and-paste

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@
 
 Adds GraphQL support to your Flask application.
 
+## Installation
+
+```shell
+pip install flask-graphql
+```
+
 ## Usage
 
 Just use the `GraphQLView` view from `flask_graphql`


### PR DESCRIPTION
This would have saved me the time to open `setup.py` just to look for the exact name of the package.
The lowercaseness in my patch is deliberate.

Thanks for this great library!