### PR TITLE
Fixed the context option

### DIFF
--- a/flask_graphql/graphqlview.py
+++ b/flask_graphql/graphqlview.py
@@ -22,6 +22,7 @@ class GraphQLView(View):
     graphiql_template = None
     graphiql_html_title = None
     middleware = None
+    context = None
     batch = False
 
     methods = ['GET', 'POST', 'PUT', 'DELETE']
@@ -39,7 +40,7 @@ class GraphQLView(View):
         return self.root_value
 
     def get_context(self):
-        return request
+        return self.context or request
 
     def get_middleware(self):
         return self.middleware

--- a/tests/test_graphqlview.py
+++ b/tests/test_graphqlview.py
@@ -451,7 +451,7 @@ def test_passes_request_into_request_context(client):
     }
 
 
-@pytest.mark.parametrize('app', [create_app(get_context=lambda:"CUSTOM CONTEXT")])
+@pytest.mark.parametrize('app', [create_app(context="CUSTOM CONTEXT")])
 def test_supports_pretty_printing(client):
     response = client.get(url_string(query='{context}'))
 
@@ -514,8 +514,8 @@ def test_batch_supports_post_json_query_with_json_variables(client):
         # 'id': 1,
         'data': {'test': "Hello Dolly"}
     }]
- 
-          
+
+
 @pytest.mark.parametrize('app', [create_app(batch=True)])
 def test_batch_allows_post_with_operation_name(client):
     response = client.post(


### PR DESCRIPTION
Readded the context option which was removed in d728f80. With this change, `GraphQLView` behaves as described in the documentation.

From the README:
 * `context`: A value to pass as the `context` to the `graphql()` function.

This should also fix #52.