### PR TITLE
Update context and root executor options

### DIFF
--- a/flask_graphql/graphqlview.py
+++ b/flask_graphql/graphqlview.py
@@ -38,7 +38,7 @@ class GraphQLView(View):
     def get_root_value(self):
         return self.root_value
 
-    def get_context(self):
+    def get_context_value(self):
         return request
 
     def get_middleware(self):
@@ -89,8 +89,8 @@ class GraphQLView(View):
                 backend=self.get_backend(),
 
                 # Execute options
-                root=self.get_root_value(),
-                context=self.get_context(),
+                root_value=self.get_root_value(),
+                context_value=self.get_context_value(),
                 middleware=self.get_middleware(),
                 **extra_options
             )

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,10 @@
 from setuptools import setup, find_packages
 
-required_packages = ["graphql-core>=2.1,<3", "flask>=0.7.0", "graphql-server-core>=1.1,<2"]
+required_packages = [
+    "graphql-core>=2.3,<3",
+    "flask>=0.7.0",
+    "graphql-server-core>=1.1,<2",
+]
 
 setup(
     name="Flask-GraphQL",

--- a/tests/test_graphiqlview.py
+++ b/tests/test_graphiqlview.py
@@ -23,7 +23,7 @@ def test_graphiql_renders_pretty(client):
         '    "test": "Hello World"\n'
         '  }\n'
         '}'
-    ).replace("\"","\\\"").replace("\n","\\n")
+    ).replace("\"", "\\\"").replace("\n", "\\n")
 
     assert pretty_response in response.data.decode('utf-8')
 
@@ -34,6 +34,6 @@ def test_graphiql_default_title(client):
 
 
 @pytest.mark.parametrize('app', [create_app(graphiql=True, graphiql_html_title="Awesome")])
-def test_graphiql_custom_title(client):
+def test_graphiql_custom_title(app, client):
     response = client.get(url_for('graphql'), headers={'Accept': 'text/html'})
     assert '<title>Awesome</title>' in response.data.decode('utf-8')

--- a/tests/test_graphqlview.py
+++ b/tests/test_graphqlview.py
@@ -19,6 +19,7 @@ from flask import url_for
 def app():
     return create_app()
 
+
 def url_string(**url_params):
     string = url_for('graphql')
 
@@ -328,7 +329,7 @@ def test_allows_post_with_get_operation_name(client):
 
 
 @pytest.mark.parametrize('app', [create_app(pretty=True)])
-def test_supports_pretty_printing(client):
+def test_supports_pretty_printing(app, client):
     response = client.get(url_string(query='{test}'))
 
     assert response.data.decode() == (
@@ -341,7 +342,7 @@ def test_supports_pretty_printing(client):
 
 
 @pytest.mark.parametrize('app', [create_app(pretty=False)])
-def test_not_pretty_by_default(client):
+def test_not_pretty_by_default(app, client):
     response = client.get(url_string(query='{test}'))
 
     assert response.data.decode() == (
@@ -451,10 +452,9 @@ def test_passes_request_into_request_context(client):
     }
 
 
-@pytest.mark.parametrize('app', [create_app(get_context=lambda:"CUSTOM CONTEXT")])
-def test_supports_pretty_printing(client):
+@pytest.mark.parametrize('app', [create_app(get_context_value=lambda:"CUSTOM CONTEXT")])
+def test_supports_pretty_printing_with_custom_context(app, client):
     response = client.get(url_string(query='{context}'))
-
 
     assert response.status_code == 200
     assert response_json(response) == {
@@ -468,7 +468,7 @@ def test_post_multipart_data(client):
     query = 'mutation TestMutation { writeTest { test } }'
     response = client.post(
         url_string(),
-        data= {
+        data={
             'query': query,
             'file': (StringIO(), 'text1.txt'),
         },
@@ -480,7 +480,7 @@ def test_post_multipart_data(client):
 
 
 @pytest.mark.parametrize('app', [create_app(batch=True)])
-def test_batch_allows_post_with_json_encoding(client):
+def test_batch_allows_post_with_json_encoding(app, client):
     response = client.post(
         url_string(),
         data=jl(
@@ -498,7 +498,7 @@ def test_batch_allows_post_with_json_encoding(client):
 
 
 @pytest.mark.parametrize('app', [create_app(batch=True)])
-def test_batch_supports_post_json_query_with_json_variables(client):
+def test_batch_supports_post_json_query_with_json_variables(app, client):
     response = client.post(
         url_string(),
         data=jl(
@@ -514,10 +514,10 @@ def test_batch_supports_post_json_query_with_json_variables(client):
         # 'id': 1,
         'data': {'test': "Hello Dolly"}
     }]
- 
-          
+
+
 @pytest.mark.parametrize('app', [create_app(batch=True)])
-def test_batch_allows_post_with_operation_name(client):
+def test_batch_allows_post_with_operation_name(app, client):
     response = client.post(
         url_string(),
         data=jl(


### PR DESCRIPTION
## 📦 Enhancement

Fixes #70 and Fixes #71

- [x] Bump graphl-core minimum version to 2.3 (was 2.1).
- [x] Provide `context_value` and `root_value` to executor options (was `context` and `root`).